### PR TITLE
switch to go-buffer-pool

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,6 @@
       "version": "1.5.7"
     },
     {
-      "author": "jbenet",
-      "hash": "QmWBug6eBS7AxRdCDVuSY5CnSit7cS2XnPFYJWqWDumhCG",
-      "name": "go-msgio",
-      "version": "0.0.3"
-    },
-    {
       "author": "whyrusleeping",
       "hash": "QmZooytqEoUwQjv7KzH4d3xyJnyvD3AWJaCDMYt5pbCtua",
       "name": "chunker",
@@ -35,6 +29,12 @@
       "hash": "QmRcHuYzAyswytBuMF78rj3LTChYszomRFXNg4685ZN1WM",
       "name": "go-block-format",
       "version": "0.2.0"
+    },
+    {
+      "author": "Stebalien",
+      "hash": "QmUQy76yspPa3fRyY3GzXFTg9n8JVwFru6ue3KFRt4MeTw",
+      "name": "go-buffer-pool",
+      "version": "0.1.1"
     }
   ],
   "gxVersion": "0.12.1",


### PR DESCRIPTION
It has a nicer interface and we don't even need the rest of the msgio

Prereq for: https://github.com/libp2p/go-msgio/pull/9