### PR TITLE
add fastcdc chunker

### DIFF
--- a/fastcdc.go
+++ b/fastcdc.go
@@ -1,0 +1,39 @@
+package chunk
+
+import (
+	"github.com/jotfs/fastcdc-go"
+	"io"
+)
+
+type FastCDC struct {
+	r io.Reader
+	*fastcdc.Chunker
+}
+
+func NewFastCDC(r io.Reader, min, avg, max int) *FastCDC {
+	opts := fastcdc.Options{
+		MinSize:     min,
+		AverageSize: avg,
+		MaxSize:     max,
+	}
+	c, err := fastcdc.NewChunker(r, opts)
+	if err != nil {
+		panic(err)
+	}
+	return &FastCDC{
+		r,
+		c,
+	}
+}
+
+func (f *FastCDC) Reader() io.Reader {
+	return f.r
+}
+
+func (f *FastCDC) NextBytes() ([]byte, error) {
+	chnk, err := f.Next()
+	if err != nil {
+		return nil, err
+	}
+	return chnk.Data, nil
+}

--- a/fastcdc_test.go
+++ b/fastcdc_test.go
@@ -1,0 +1,98 @@
+package chunk
+
+import (
+	"bytes"
+	util "github.com/ipfs/go-ipfs-util"
+	"io"
+	"testing"
+)
+
+func TestFastCDCChunking(t *testing.T) {
+	const (
+		min = 2048
+		avg = 4096
+		max = 8192
+	)
+	data := make([]byte, 1024*1024*16)
+
+	rounds := 100
+
+	for i := 0; i < rounds; i++ {
+		util.NewTimeSeededRand().Read(data)
+
+		r := NewFastCDC(bytes.NewReader(data), min, avg, max)
+
+		var chunkCount int
+		var length int
+		var unchunked []byte
+		for {
+			chunk, err := r.NextBytes()
+			if err != nil {
+				if err == io.EOF {
+					break
+				}
+				t.Fatal(err)
+			}
+
+			if len(chunk) == 0 {
+				t.Fatalf("chunk %d/%d is empty", chunkCount+1, len(chunk))
+			}
+
+			length += len(chunk)
+
+			if len(chunk) < min && length != len(data) {
+				t.Fatalf("chunk %d/%d is less than the minimum size", chunkCount+1, len(chunk))
+			}
+
+			if len(chunk) > max {
+				t.Fatalf("chunk %d/%d is more than the maximum size", chunkCount+1, len(chunk))
+			}
+
+			unchunked = append(unchunked, chunk...)
+			chunkCount++
+		}
+
+		if !bytes.Equal(unchunked, data) {
+			t.Fatal("data was chunked incorrectly")
+		}
+
+		t.Logf("average block size: %d\n", len(data)/chunkCount)
+	}
+}
+
+//func TestFastCDCChunkReuse(t *testing.T) {
+//	newFastCDC := func(r io.Reader) Splitter {
+//		return NewFastCDC(r,4096,65536,262144)
+//	}
+//	testReuse(t, newFastCDC)
+//}
+
+func BenchmarkFastCDC4K(b *testing.B) {
+	benchmarkChunker(b, func(r io.Reader) Splitter {
+		return NewFastCDC(r, 2048, 4096, 8192)
+	})
+}
+
+func BenchmarkFastCDC16K(b *testing.B) {
+	benchmarkChunker(b, func(r io.Reader) Splitter {
+		return NewFastCDC(r, 8192, 16384, 32768)
+	})
+}
+
+func BenchmarkFastCDC32K(b *testing.B) {
+	benchmarkChunker(b, func(r io.Reader) Splitter {
+		return NewFastCDC(r, 16384, 32768, 65536)
+	})
+}
+
+func BenchmarkFastCDC64K(b *testing.B) {
+	benchmarkChunker(b, func(r io.Reader) Splitter {
+		return NewFastCDC(r, 32768, 65536, 131072)
+	})
+}
+
+func BenchmarkFastCDC128K(b *testing.B) {
+	benchmarkChunker(b, func(r io.Reader) Splitter {
+		return NewFastCDC(r, 65536, 131072, 262144)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-ipfs-util v0.0.1
 	github.com/ipfs/go-log v0.0.1
+	github.com/jotfs/fastcdc-go v0.2.0 // indirect
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
+github.com/jotfs/fastcdc-go v0.2.0 h1:WHYIGk3k9NumGWfp4YMsemEcx/s4JKpGAa6tpCpHJOo=
+github.com/jotfs/fastcdc-go v0.2.0/go.mod h1:PGFBIloiASFbiKnkCd/hmHXxngxYDYtisyurJ/zyDNM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/libp2p/go-buffer-pool v0.0.2 h1:QNK2iAFa8gjAe1SPz6mHSMuCcjs+X1wlHzeOSqcmlfs=

--- a/parse_test.go
+++ b/parse_test.go
@@ -78,3 +78,22 @@ func TestParseSize(t *testing.T) {
 		t.Fatalf("Expected 'ErrSizeMax', got: %#v", err)
 	}
 }
+
+func TestParseFastCDC(t *testing.T) {
+	r := bytes.NewReader(randBuf(t, 1000))
+
+	_, err := FromString(r, "fastcdc-64-128-256")
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+
+	_, err = FromString(r, fmt.Sprintf("fastcdc-64-128-%d", ChunkSizeLimit))
+	if err != nil {
+		t.Fatalf("Expected success, got: %#v", err)
+	}
+
+	_, err = FromString(r, fmt.Sprintf("fastcdc-64-128-%d", 1+ChunkSizeLimit))
+	if err != ErrSizeMax {
+		t.Fatalf("Expected 'ErrSizeMax', got: %#v", err)
+	}
+}


### PR DESCRIPTION
fastcdc is the fastest content-defined chunking algorithm at present, see [fastcdc](https://www.usenix.org/system/files/conference/atc16/atc16-paper-xia.pdf). I used the go implementation of the fastcdc, see [fastcdc-go](https://github.com/jotfs/fastcdc-go).
On Intel(R) Core(TM) i7-7700 @2.8GHz, the chunking speed is almost 1.7GB/s, 1.5x faster than buzhash, and 8x faster than rabin.
Here are some benchmarks:
`fastcdc`:
```
goos: windows
goarch: amd64
pkg: github.com/ipfs/go-ipfs-chunker
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkFastCDC16K/1K
BenchmarkFastCDC16K/1K-8         	   92290	     11982 ns/op	  85.46 MB/s	   65720 B/op	       4 allocs/op
BenchmarkFastCDC16K/1M
BenchmarkFastCDC16K/1M-8         	    2086	    640652 ns/op	1636.73 MB/s	   65720 B/op	       4 allocs/op
BenchmarkFastCDC16K/16M
BenchmarkFastCDC16K/16M-8        	     122	   9521200 ns/op	1762.09 MB/s	   65720 B/op	       4 allocs/op
BenchmarkFastCDC16K/100M
BenchmarkFastCDC16K/100M-8       	      19	  60218868 ns/op	1741.27 MB/s	   65720 B/op	       4 allocs/op
```
`buzhash`:
```
goos: windows
goarch: amd64
pkg: github.com/ipfs/go-ipfs-chunker
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkBuzhash2
BenchmarkBuzhash2/1K
BenchmarkBuzhash2/1K-8         	 1899345	       608.5 ns/op	1682.86 MB/s	    1231 B/op	       3 allocs/op
BenchmarkBuzhash2/1M
BenchmarkBuzhash2/1M-8         	    1189	    950964 ns/op	1102.65 MB/s	 1074246 B/op	       8 allocs/op
BenchmarkBuzhash2/16M
BenchmarkBuzhash2/16M-8        	      79	  15435477 ns/op	1086.93 MB/s	17071196 B/op	      72 allocs/op
BenchmarkBuzhash2/100M
BenchmarkBuzhash2/100M-8       	      13	  89292162 ns/op	1174.32 MB/s	106415715 B/op	     405 allocs/op
```
`rabin`:
```
goos: windows
goarch: amd64
pkg: github.com/ipfs/go-ipfs-chunker
cpu: Intel(R) Core(TM) i7-7700HQ CPU @ 2.80GHz
BenchmarkRabin
BenchmarkRabin/1K
BenchmarkRabin/1K-8         	   13327	     75075 ns/op	  13.64 MB/s	  402478 B/op	       8 allocs/op
BenchmarkRabin/1M
BenchmarkRabin/1M-8         	     206	   5773018 ns/op	 181.63 MB/s	 2846848 B/op	      23 allocs/op
BenchmarkRabin/16M
BenchmarkRabin/16M-8        	      14	  78756929 ns/op	 213.03 MB/s	19800166 B/op	     205 allocs/op
BenchmarkRabin/100M
BenchmarkRabin/100M-8       	       3	 479963967 ns/op	 218.47 MB/s	108976733 B/op	    1208 allocs/op
```